### PR TITLE
Correct a broken link which occasionally might be important for you

### DIFF
--- a/src/review_heatmap/libaddon/gui/dialog_contrib.py
+++ b/src/review_heatmap/libaddon/gui/dialog_contrib.py
@@ -97,4 +97,4 @@ class ContribDialog(BasicDialog):
             return openLink(url)
         protocol, cmd = url.split("://")
         if cmd == "installed-addons":
-            openLink("https://ankiweb.net/shared/byauthor/1771074083")
+            openLink("https://ankiweb.net/shared/by-author/1771074083")


### PR DESCRIPTION
There is a link in the support dialog supposed to open the ankiweb page, listing all  your add-ons, which assumingly changed over time. This now is the corrected version.

Thanks for your great work!